### PR TITLE
ci: restrict push trigger to main branch only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     tags: ["v*"]
   pull_request:
     branches: ["**"]


### PR DESCRIPTION
Restrict the `push` trigger to `main` only, since `pull_request` events already cover feature branches when a PR is open, avoiding redundant CI runs on every branch push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)