### PR TITLE
ci: remove redundant go build step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Build
-        run: go build ./...
-
       - name: Test
         run: go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
 


### PR DESCRIPTION
## Summary

- Removes the `go build ./...` step from the `test` job in the CI workflow
- The `go test` command already fails if the code does not compile, making the explicit build step redundant
- This reduces CI execution time by eliminating a duplicate compilation pass

## Test plan

- [ ] Verify the `Test` workflow runs successfully without the `Build` step
- [ ] Confirm that a compilation error would still cause the `go test` step to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)