### PR TITLE
ci: auto-merge Dependabot PRs when tests pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Enable auto-merge at repository level
- Add workflow `dependabot-auto-merge.yml` that activates on any Dependabot PR and calls `gh pr merge --auto --squash`

## How it works

1. Dependabot opens a PR
2. `dependabot-auto-merge.yml` runs immediately and sets the auto-merge flag on the PR
3. The `Test` workflow runs (lint → test → integration-test)
4. If all checks pass, GitHub merges the PR automatically
5. If any check fails, the PR stays open for manual review

> Note: `--auto` requires auto-merge to be enabled on the repository (done).
> Adding branch protection rules with required status checks will make this more robust.