### PR TITLE
build: reduce binary size by 30% with -s -w -trimpath

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,8 +44,9 @@ tasks:
     desc: Build the binary
     cmds:
       - |
-        go build -ldflags \
-          "-X github.com/matrixise/rmm-tracker/cmd.Version={{.VERSION}} \
+        go build -trimpath -ldflags \
+          "-s -w \
+           -X github.com/matrixise/rmm-tracker/cmd.Version={{.VERSION}} \
            -X github.com/matrixise/rmm-tracker/cmd.GitCommit={{.GIT_COMMIT}} \
            -X github.com/matrixise/rmm-tracker/cmd.BuildTime={{.BUILD_TIME}}" \
           -o {{.BINARY}} .


### PR DESCRIPTION
## Summary

- Add `-s` (strip symbol table), `-w` (strip DWARF debug info) and `-trimpath` to `go build` in `Taskfile.yml`
- **30 MB → 21 MB** on darwin/arm64 (-30%)

## Trade-offs

Stripping DWARF means production stack traces show raw addresses without function names. Acceptable here since:
- Errors are propagated with `%w` and logged via `slog`
- No post-mortem profiling workflow currently in place

A separate `build:debug` task can be added later if needed.

## Test plan

- [ ] `task build` succeeds
- [ ] `ls -lh rmm-tracker` shows ~21 MB
- [ ] Binary runs correctly: `./rmm-tracker version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)