### PR TITLE
feat(web): migrate Tailwind CSS CDN from v3 to v4.2

### DIFF
--- a/internal/web/templates/layout.templ
+++ b/internal/web/templates/layout.templ
@@ -8,7 +8,7 @@ templ Layout(title string) {
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<title>{ title } — RMM Tracker</title>
 			<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2/dist/index.global.js"></script>
-		<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+			<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
 		</head>
 		<body class="h-full">
 			<nav class="bg-white shadow-sm">

--- a/internal/web/templates/layout_templ.go
+++ b/internal/web/templates/layout_templ.go
@@ -36,7 +36,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" — RMM Tracker</title><script src=\"https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2/dist/index.global.js\"></script><script defer src=\"https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js\"></script></head><body class=\"h-full\"><nav class=\"bg-white shadow-sm\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8\"><div class=\"flex h-12 items-center gap-6\"><span class=\"font-bold text-indigo-600\">RMM Tracker</span> <a href=\"/\" class=\"text-sm font-medium text-gray-600 hover:text-gray-900\">Dashboard</a> <a href=\"/wallets\" class=\"text-sm font-medium text-gray-600 hover:text-gray-900\">Wallets</a></div></div></nav><main class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" — RMM Tracker</title><script src=\"https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.2/dist/index.global.js\"></script><script defer src=\"https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js\"></script></head><body class=\"h-full\"><nav class=\"bg-white shadow-sm\"><div class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8\"><div class=\"flex h-12 items-center gap-6\"><span class=\"font-bold text-indigo-600\">RMM Tracker</span> <a href=\"/\" class=\"text-sm font-medium text-gray-600 hover:text-gray-900\">Dashboard</a> <a href=\"/wallets\" class=\"text-sm font-medium text-gray-600 hover:text-gray-900\">Wallets</a></div></div></nav><main class=\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

Pin all CDN dependencies in `layout.templ` to exact versions for reproducible builds.

### Tailwind CSS: v3 Play CDN → `@tailwindcss/browser@4.2`

- `cdn.tailwindcss.com` was unversioned (v3) and triggered a 302 redirect on every page load
- Replaced with `@tailwindcss/browser@4.2` via jsDelivr (direct URL, no redirect)
- No breaking changes: zero deprecated v4 classes in the templates (`bg-opacity-*`, `text-opacity-*`, etc.)

### Alpine.js: `@3` → `@3.15.8`

- `alpinejs@3` resolved to the latest 3.x at request time (same reproducibility issue)
- Pinned to `3.15.8` (current stable)
- Also fixes indentation of the `<script>` tag (was 2 tabs, consistent with surrounding `<head>` at 3 tabs)

## Test plan

- [ ] `task build` passes
- [ ] Open `http://localhost:8080` — Dashboard, Wallets, WalletDetail render correctly
- [ ] DevTools Network: no 302 on either jsDelivr request

🤖 Generated with [Claude Code](https://claude.com/claude-code)