### PR TITLE
refactor(storage): introduce CQRS interfaces (Commander / Querier)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -291,7 +291,7 @@ func logRPCConnection(rpcURLs []string) {
 	}
 }
 
-func processAllWallets(ctx context.Context, cfg *config.Config, client *blockchain.Client, store *storage.Store) error {
+func processAllWallets(ctx context.Context, cfg *config.Config, client *blockchain.Client, store storage.Commander) error {
 	for _, walletAddr := range cfg.Wallets {
 		// Check for cancellation
 		select {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -12,11 +12,11 @@ import (
 
 // Handler holds dependencies for API handlers.
 type Handler struct {
-	store storage.Storer
+	store storage.Querier
 }
 
 // NewHandler creates a new Handler.
-func NewHandler(store storage.Storer) *Handler {
+func NewHandler(store storage.Querier) *Handler {
 	return &Handler{store: store}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -31,7 +31,7 @@ func slogLogger(next http.Handler) http.Handler {
 
 // NewRouter creates a Chi router with all application routes.
 // When enableWeb is true, the web UI is mounted at "/" using the provided store and checker.
-func NewRouter(healthHandler http.HandlerFunc, apiHandler *Handler, checker *health.Checker, enableWeb bool, store storage.Storer) *chi.Mux {
+func NewRouter(healthHandler http.HandlerFunc, apiHandler *Handler, checker *health.Checker, enableWeb bool, store storage.Querier) *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(slogLogger)
 	r.Use(middleware.Recoverer)

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -28,7 +28,7 @@ type BuildInfo struct {
 
 // Checker performs health checks on application dependencies
 type Checker struct {
-	store          *storage.Store
+	store          storage.Pinger
 	client         *blockchain.Client
 	scheduler      SchedulerInterface
 	buildInfo      BuildInfo
@@ -39,7 +39,7 @@ type Checker struct {
 }
 
 // NewChecker creates a new health checker
-func NewChecker(store *storage.Store, client *blockchain.Client, scheduler SchedulerInterface, interval time.Duration, buildInfo BuildInfo) *Checker {
+func NewChecker(store storage.Pinger, client *blockchain.Client, scheduler SchedulerInterface, interval time.Duration, buildInfo BuildInfo) *Checker {
 	return &Checker{
 		store:     store,
 		client:    client,

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -2,16 +2,31 @@ package storage
 
 import "context"
 
-// Storer is the interface implemented by Store.
-// It is exposed for dependency injection and mocking in tests.
-type Storer interface {
+// Commander is the write-side interface (used by the blockchain tracker).
+type Commander interface {
 	BatchInsertBalances(ctx context.Context, balances []TokenBalance) error
+}
+
+// Querier is the read-side interface (used by API, web UI).
+type Querier interface {
 	GetBalances(ctx context.Context, wallet, symbol string, limit int) ([]TokenBalance, error)
 	GetDailyBalances(ctx context.Context, wallet string) ([]DailyBalance, error)
 	GetDailyReport(ctx context.Context, wallet string, days int) ([]DailyReport, error)
 	GetWeeklyBalances(ctx context.Context, wallet string) ([]WeeklyBalance, error)
 	GetWeeklyReport(ctx context.Context, wallet string, weeks int) ([]WeeklyReport, error)
 	GetWallets(ctx context.Context) ([]string, error)
+}
+
+// Pinger is a connectivity probe interface (used by health checks).
+type Pinger interface {
 	Ping(ctx context.Context) error
+}
+
+// Storer composes Commander, Querier, and Pinger. It is the wiring point used
+// in cmd/ and implemented by every storage backend.
+type Storer interface {
+	Commander
+	Querier
+	Pinger
 	Close()
 }

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -12,12 +12,12 @@ import (
 
 // WebHandler holds dependencies for web UI handlers.
 type WebHandler struct {
-	store   storage.Storer
+	store   storage.Querier
 	checker *health.Checker
 }
 
 // NewWebHandler creates a new WebHandler.
-func NewWebHandler(store storage.Storer, checker *health.Checker) *WebHandler {
+func NewWebHandler(store storage.Querier, checker *health.Checker) *WebHandler {
 	return &WebHandler{store: store, checker: checker}
 }
 


### PR DESCRIPTION
## Summary

- Split `Storer` into `Commander` (write) + `Querier` (read) + `Storer` (composition of both)
- `api/handlers.go`, `api/router.go`, `web/handler.go`: depend on `Querier` instead of `Storer`
- `health/health.go`: `*storage.Store` → `storage.Querier` in `NewChecker`
- `cmd/run.go` `processAllWallets`: `*storage.Store` → `storage.Commander`

**No dependency changes** — pure interface refactoring, reviewable independently.

## Rationale

Separating read and write interfaces enforces the principle of least privilege:
- Components that only read (API handlers, web UI, health checks) can no longer accidentally call `BatchInsertBalances`
- The blockchain tracker (`processAllWallets`) only needs `Commander` — it cannot call any `Get*` method
- Every storage backend (`Store`, `DuckDBStore`) implements `Storer` = `Commander` + `Querier`, so wiring in `cmd/` remains unchanged

## Test plan

- [x] `go build ./...` — no errors
- [x] `go test -count=1 ./internal/...` — all packages pass
- [x] No go.mod / go.sum changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)