### PR TITLE
fix(docker): fix Go module cache in CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ ENV GOTOOLCHAIN=auto
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
+RUN go mod download
 
 COPY . .
 
@@ -30,8 +29,7 @@ ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
 
 # Build
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-X github.com/matrixise/rmm-tracker/cmd.Version=${VERSION} -X github.com/matrixise/rmm-tracker/cmd.GitBranch=${GIT_BRANCH} -X github.com/matrixise/rmm-tracker/cmd.GitCommit=${GIT_COMMIT} -X github.com/matrixise/rmm-tracker/cmd.BuildTime=${BUILD_TIME}" \
     -o rmm-tracker .


### PR DESCRIPTION
## Summary

- Remove `--mount=type=cache,target=/go/pkg/mod` from `go mod download` — downloaded modules now become part of the image layer and are correctly cached by `type=gha`
- Remove `--mount=type=cache,target=/go/pkg/mod` from `go build` — the build now reads modules from the image layer instead of the empty BuildKit daemon cache
- Keep `--mount=type=cache,target=/root/.cache/go-build` on the build step (useful locally, no-op in CI)

## Root cause

BuildKit cache mounts (`--mount=type=cache`) are stored in the local BuildKit daemon — they are **not** exported by `cache-to: type=gha`. On each CI run the daemon is fresh, so `/go/pkg/mod` was always empty, causing all Go dependencies to be re-downloaded even when `go.mod`/`go.sum` were unchanged.

## Expected result

| Scenario | Before | After |
|----------|--------|-------|
| `go.mod`/`go.sum` unchanged | re-downloads everything | layer restored from GHA cache |
| `go.mod`/`go.sum` changed | re-downloads everything | re-downloads (normal invalidation) |
| Only sources changed | re-downloads + rebuild | modules cached, rebuild only |

## Test plan

- [ ] Push a commit without changing `go.mod`/`go.sum`
- [ ] Verify `go mod download` step appears as **CACHED** in Docker BuildKit logs
- [ ] Verify only `COPY . .` and `go build` steps re-execute
- [ ] Confirm overall Docker build time drops (no network download for modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)