### PR TITLE
fix(docs): fix MD060 table separator in Web UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ task docker:down     # Stop all services
 Available in daemon mode at `http://localhost:8080`.
 
 | Path | Description |
-|---|---|
+| --- | --- |
 | `/` | Dashboard — global summary |
 | `/wallets` | Wallet list with address search |
 | `/wallets/{wallet}` | Wallet detail — current balances per token |


### PR DESCRIPTION
Fix `|---|---|` → `| --- | --- |` in the Web UI table (line 121 of README.md).

Introduced by the merge of #41, caught by the `markdown-lint` CI job on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)