### PR TITLE
feat(ci): add markdownlint-cli2 and codespell to prek hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,17 @@ repos:
     rev: v2.10.1
     hooks:
       - id: golangci-lint
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.21.0
+    hooks:
+      - id: markdownlint-cli2
+        args: ["--config", ".markdownlint.yml"]
+        exclude: ^(CLAUDE\.md|IMPLEMENTATION\.md|docs/.*)$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        types: [markdown]
+        exclude: ^docs/


### PR DESCRIPTION
Add `markdownlint-cli2` and `codespell` hooks to `.pre-commit-config.yaml` so prek catches markdown and spelling issues at commit time, before they reach CI.

- `markdownlint-cli2`: uses `.markdownlint.yml`, excludes `CLAUDE.md`, `IMPLEMENTATION.md`, `docs/`
- `codespell`: runs on markdown files only, excludes `docs/` (legacy French documents)

Avoids fix PRs like #42 and #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)