### PR TITLE
docs: document prek as pre-commit replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,18 @@ Strict rules to follow when creating or modifying `Taskfile.yml`.
 
 - Vars defined with `sh:` are evaluated **once** at task startup, not before each `cmd`. Do not assume they are re-evaluated dynamically.
 
+## Pre-commit hooks (prek)
+
+This project uses [prek](https://github.com/isak-larsson/prek), a Rust-based drop-in replacement for `pre-commit`. It is **not** `pre-commit` — always use `prek` directly.
+
+```bash
+prek install        # Install hooks into .git/hooks/
+prek run -a         # Run all hooks on all files
+prek run <hook-id>  # Run a specific hook
+```
+
+The configuration lives in `.pre-commit-config.yaml` (prek reads this format natively). Hooks include: trailing whitespace, YAML lint, gofmt, golangci-lint, markdownlint-cli2, codespell.
+
 ## Worktrees
 
 Always name worktrees at creation time to avoid random names (e.g. `structured-orbiting-duckling`).

--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@ task migrate:status         # Check migration state
 task docker:buildx:push     # Build multi-arch image and push to Docker Hub
 ```
 
+### Pre-commit hooks
+
+This project uses [prek](https://github.com/isak-larsson/prek) (a Rust-based drop-in replacement for pre-commit) to run hooks on every commit: YAML linting, Go formatting, golangci-lint, markdownlint, and spell checking.
+
+```bash
+prek install   # Install hooks into .git/hooks/
+prek run -a    # Run all hooks manually
+```
+
 ## CI/CD
 
 GitHub Actions workflows:


### PR DESCRIPTION
Add a note about `prek` in both `README.md` (Development section) and `CLAUDE.md` (new Pre-commit hooks section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)