### PR TITLE
feat(taskfile): add docker:tags task to list Docker Hub tags

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -216,6 +216,21 @@ tasks:
     cmds:
       - docker buildx prune --builder rmm-builder -f
 
+  docker:tags:
+    desc: List published tags on Docker Hub
+    cmds:
+      - |
+        curl -s \
+          "https://hub.docker.com/v2/repositories/{{.DOCKER_HUB_IMAGE}}/tags?page_size=100" \
+          | python3 -c "
+        import sys, json
+        data = json.load(sys.stdin)
+        print(f'Tags for {{.DOCKER_HUB_IMAGE}} ({data[\"count\"]} total)')
+        print()
+        for t in data['results']:
+            print(f'  {t[\"name\"]:<30} {t[\"tag_last_pushed\"][:10]}')
+        "
+
   # ── Development ────────────────────────────────────────
 
   run:


### PR DESCRIPTION
Add `task docker:tags` to list all published tags for `matrixise/rmm-tracker` on Docker Hub via the API.

```
task docker:tags

Tags for matrixise/rmm-tracker (44 total)

  latest                         2026-02-28
  main                           2026-02-28
  sha-834a2bf                    2026-02-28
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)