### PR TITLE
fix(wallet): normalize wallet addresses to lowercase

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -74,7 +75,7 @@ func (h *Handler) GetDashboard(w http.ResponseWriter, r *http.Request) {
 // GetBalances handles GET /api/v1/balances
 // Query params: wallet, symbol, limit (default 100)
 func (h *Handler) GetBalances(w http.ResponseWriter, r *http.Request) {
-	wallet := r.URL.Query().Get("wallet")
+	wallet := strings.ToLower(r.URL.Query().Get("wallet"))
 	symbol := r.URL.Query().Get("symbol")
 	limitStr := r.URL.Query().Get("limit")
 
@@ -107,7 +108,7 @@ func (h *Handler) GetBalances(w http.ResponseWriter, r *http.Request) {
 
 // GetLatestBalances handles GET /api/v1/wallets/{wallet}/balances/latest
 func (h *Handler) GetLatestBalances(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -132,7 +133,7 @@ func (h *Handler) GetLatestBalances(w http.ResponseWriter, r *http.Request) {
 
 // GetWeeklyBalances handles GET /api/v1/wallets/{wallet}/balances/weekly
 func (h *Handler) GetWeeklyBalances(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -158,7 +159,7 @@ func (h *Handler) GetWeeklyBalances(w http.ResponseWriter, r *http.Request) {
 // GetWeeklyReport handles GET /api/v1/wallets/{wallet}/report/weekly
 // Optional query param: weeks (integer >= 2, default 2)
 func (h *Handler) GetWeeklyReport(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -193,7 +194,7 @@ func (h *Handler) GetWeeklyReport(w http.ResponseWriter, r *http.Request) {
 
 // GetDailyBalances handles GET /api/v1/wallets/{wallet}/balances/daily
 func (h *Handler) GetDailyBalances(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -219,7 +220,7 @@ func (h *Handler) GetDailyBalances(w http.ResponseWriter, r *http.Request) {
 // GetDailyReport handles GET /api/v1/wallets/{wallet}/report/daily
 // Optional query param: days (integer 2-365, default 31)
 func (h *Handler) GetDailyReport(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -255,7 +256,7 @@ func (h *Handler) GetDailyReport(w http.ResponseWriter, r *http.Request) {
 // GetWeeklyPeriodYield handles GET /api/v1/wallets/{wallet}/yield/weekly
 // Optional query param: weeks (integer 2-52, default 8)
 func (h *Handler) GetWeeklyPeriodYield(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return
@@ -291,7 +292,7 @@ func (h *Handler) GetWeeklyPeriodYield(w http.ResponseWriter, r *http.Request) {
 // GetDailyPeriodYield handles GET /api/v1/wallets/{wallet}/yield/daily
 // Optional query param: days (integer 2-365, default 31)
 func (h *Handler) GetDailyPeriodYield(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	if wallet == "" {
 		http.Error(w, "wallet parameter required", http.StatusBadRequest)
 		return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -237,7 +237,7 @@ func sampleWeeklyReport() storage.WeeklyReport {
 func TestGetBalances_ReturnsBalances(t *testing.T) {
 	ms := &mockStore{
 		getBalancesFn: func(_ context.Context, wallet, symbol string, limit int) ([]storage.TokenBalance, error) {
-			assert.Equal(t, "0xABC", wallet)
+			assert.Equal(t, "0xabc", wallet)
 			assert.Equal(t, "", symbol)
 			assert.Equal(t, 100, limit)
 			return []storage.TokenBalance{sampleBalance()}, nil
@@ -335,7 +335,7 @@ func TestGetBalances_SymbolFilter(t *testing.T) {
 func TestGetWeeklyBalances_ReturnsBalances(t *testing.T) {
 	ms := &mockStore{
 		getWeeklyBalancesFn: func(_ context.Context, wallet string) ([]storage.WeeklyBalance, error) {
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.WeeklyBalance{sampleWeeklyBalance()}, nil
 		},
 	}
@@ -383,7 +383,7 @@ func TestGetWeeklyReport_DefaultWeeks_Returns200(t *testing.T) {
 	ms := &mockStore{
 		getWeeklyReportFn: func(_ context.Context, wallet string, weeks int) ([]storage.WeeklyReport, error) {
 			capturedWeeks = weeks
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.WeeklyReport{sampleWeeklyReport()}, nil
 		},
 	}
@@ -489,7 +489,7 @@ func TestGetWeeklyReport_EmptyResult_ReturnsEmptyArray(t *testing.T) {
 func TestGetDailyBalances_ReturnsBalances(t *testing.T) {
 	ms := &mockStore{
 		getDailyBalancesFn: func(_ context.Context, wallet string) ([]storage.DailyBalance, error) {
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.DailyBalance{sampleDailyBalance()}, nil
 		},
 	}
@@ -539,7 +539,7 @@ func TestGetDailyReport_DefaultDays_Returns200(t *testing.T) {
 	ms := &mockStore{
 		getDailyReportFn: func(_ context.Context, wallet string, days int) ([]storage.DailyReport, error) {
 			capturedDays = days
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.DailyReport{sampleDailyReport()}, nil
 		},
 	}
@@ -645,7 +645,7 @@ func TestGetWeeklyPeriodYield_DefaultWeeks_Returns200(t *testing.T) {
 	ms := &mockStore{
 		getWeeklyPeriodYieldFn: func(_ context.Context, wallet string, weeks int) ([]storage.PeriodYield, error) {
 			capturedWeeks = weeks
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.PeriodYield{samplePeriodYield()}, nil
 		},
 	}
@@ -751,7 +751,7 @@ func TestGetDailyPeriodYield_DefaultDays_Returns200(t *testing.T) {
 	ms := &mockStore{
 		getDailyPeriodYieldFn: func(_ context.Context, wallet string, days int) ([]storage.PeriodYield, error) {
 			capturedDays = days
-			assert.Equal(t, "0xWALLET", wallet)
+			assert.Equal(t, "0xwallet", wallet)
 			return []storage.PeriodYield{samplePeriodYield()}, nil
 		},
 	}

--- a/internal/storage/migrations/007_lowercase_wallet_addresses.sql
+++ b/internal/storage/migrations/007_lowercase_wallet_addresses.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Normalize existing wallet addresses to lowercase.
+-- Ethereum addresses are case-insensitive; storing them in a consistent
+-- case ensures that index lookups always hit regardless of the input case.
+UPDATE token_balances
+    SET wallet = LOWER(wallet)
+    WHERE wallet <> LOWER(wallet);
+
+-- +goose Down
+
+-- Lowercase is a one-way normalization: the original case is not recoverable.
+-- This down migration is intentionally a no-op.

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -76,7 +77,7 @@ func (s *Store) BatchInsertBalances(ctx context.Context, balances []TokenBalance
 			(queried_at, wallet, token_address, symbol, decimals, raw_balance, balance)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 			bal.QueriedAt,
-			bal.Wallet,
+			strings.ToLower(bal.Wallet),
 			bal.TokenAddress,
 			bal.Symbol,
 			bal.Decimals,

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/matrixise/rmm-tracker/internal/health"
@@ -39,7 +40,7 @@ func (h *WebHandler) Wallets(w http.ResponseWriter, r *http.Request) {
 
 // WalletDetail handles GET /wallets/{wallet}
 func (h *WebHandler) WalletDetail(w http.ResponseWriter, r *http.Request) {
-	wallet := chi.URLParam(r, "wallet")
+	wallet := strings.ToLower(chi.URLParam(r, "wallet"))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := templates.WalletDetail(wallet).Render(r.Context(), w); err != nil {
 		slog.Error("render wallet detail", "error", err)


### PR DESCRIPTION
## Summary

- Add SQL migration `007_lowercase_wallet_addresses.sql` to normalize existing rows (`UPDATE token_balances SET wallet = LOWER(wallet)`)
- Apply `strings.ToLower()` to all wallet params in API handlers (`GetBalances`, `GetLatestBalances`, `GetWeeklyBalances`, `GetWeeklyReport`, `GetDailyBalances`, `GetDailyReport`, `GetWeeklyPeriodYield`, `GetDailyPeriodYield`)
- Apply `strings.ToLower()` in `BatchInsertBalances` to normalize on every write
- Apply `strings.ToLower()` to `WalletDetail` in the web handler
- Update test assertions to expect lowercase wallet values

## Test plan

- [x] All 126 unit tests pass
- [x] Pre-commit hooks (gofmt, golangci-lint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)