### PR TITLE
docs: update CHANGELOG for #52 and add PR checklist to CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wallet detail page made responsive on mobile: address wraps with `break-all`, tables scroll horizontally, padding adapts to screen size (#52)
+
 ## [0.1.0] - 2026-03-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,16 @@ Use it for navigation tasks that gopls MCP does not cover (e.g. cross-file jump-
 Using `Read` alone on a `.go` file without following up with `go_file_context` is insufficient.
 Always combine both to understand intra-package dependencies.
 
+## PR Checklist
+
+Before opening any pull request, always:
+
+1. **Update `CHANGELOG.md`** — add an entry under `## [Unreleased]` in the appropriate section (`Added`, `Changed`, or `Fixed`) with a short description and the PR number (e.g. `(#52)`).
+2. **Run tests** — `task test`
+3. **Squash + auto-merge** — `gh pr merge <n> --squash --auto`
+
+Never skip step 1. The CHANGELOG is the source of truth for release notes.
+
 ## Related Documentation
 
 - `README.md` - User-facing quick start


### PR DESCRIPTION
## Summary

- Add missing CHANGELOG entry under `[Unreleased]` for the responsive fix (#52)
- Add a **PR Checklist** section in `CLAUDE.md` to ensure future PRs always include a CHANGELOG update

## Test plan

- [ ] Verify `CHANGELOG.md` contains the responsive fix entry under `[Unreleased]`
- [ ] Verify `CLAUDE.md` contains the PR checklist section

🤖 Generated with [Claude Code](https://claude.com/claude-code)