### PR TITLE
fix(docker): stop shipping an amd64 binary in the arm64 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Published `linux/arm64` image no longer contains an amd64 binary: `ARG TARGETARCH=amd64` masked the value injected by buildx, pinning every platform to `GOARCH=amd64`. The final stage now verifies the binary's ELF architecture against the image architecture and fails the build on mismatch (#124)
 - Wallet detail page made responsive on mobile: address wraps with `break-all`, tables scroll horizontally, padding adapts to screen size (#52)
 
 ## [0.1.0] - 2026-03-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Published `linux/arm64` image no longer contains an amd64 binary: `ARG TARGETARCH=amd64` masked the value injected by buildx, pinning every platform to `GOARCH=amd64`. The final stage now verifies the binary's ELF architecture against the image architecture and fails the build on mismatch (#124)
+- Published `linux/arm64` image no longer contains an amd64 binary: `ARG TARGETARCH=amd64` masked the value injected by buildx, pinning every platform to `GOARCH=amd64`. The final stage now verifies the binary's ELF architecture against the image architecture and fails the build on mismatch (#125)
 - Wallet detail page made responsive on mobile: address wraps with `break-all`, tables scroll horizontally, padding adapts to screen size (#52)
 
 ## [0.1.0] - 2026-03-01

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,16 +33,37 @@ ARG GIT_COMMIT=unknown
 ARG BUILD_TIME=unknown
 
 # Injected by Docker buildx: TARGETOS=linux, TARGETARCH=amd64|arm64
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+#
+# These ARGs MUST stay without a default value.  Giving a predefined platform
+# ARG a default masks the value buildx injects: the stage then sees the literal
+# default for every target platform.  That is what shipped an amd64 binary
+# inside the arm64 image (see issue #124) -- `ARG TARGETARCH=amd64` pinned the
+# arm64 build to GOARCH=amd64 while the final stage was still tagged arm64.
+ARG TARGETOS
+ARG TARGETARCH
 
 # CGO_ENABLED=0 + GOOS/GOARCH → pure-Go cross-compilation running natively on
 # the build host.  No QEMU emulation needed for the compilation itself.
 # Cache key is per-TARGETARCH so amd64 and arm64 caches don't collide.
+#
+# The trailing check is a hard guard: it reads GOOS/GOARCH back out of the
+# binary's own build metadata and fails the build on any mismatch, so a
+# wrong-architecture image can never be published silently again.
 RUN --mount=type=cache,target=/root/.cache/go-build,id=go-build-${TARGETARCH} \
+    set -eu; \
+    : "${TARGETOS:?not injected by buildx -- build with docker buildx}"; \
+    : "${TARGETARCH:?not injected by buildx -- build with docker buildx}"; \
+    echo "==> target ${TARGETOS}/${TARGETARCH} (build host $(go env GOHOSTOS)/$(go env GOHOSTARCH))"; \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags "-X github.com/matrixise/rmm-tracker/cmd.Version=${VERSION} -X github.com/matrixise/rmm-tracker/cmd.GitBranch=${GIT_BRANCH} -X github.com/matrixise/rmm-tracker/cmd.GitCommit=${GIT_COMMIT} -X github.com/matrixise/rmm-tracker/cmd.BuildTime=${BUILD_TIME}" \
-    -o rmm-tracker .
+    -o rmm-tracker .; \
+    built_os="$(go version -m rmm-tracker | awk '$1=="build" && $2 ~ /^GOOS=/ {print substr($2, 6)}')"; \
+    built_arch="$(go version -m rmm-tracker | awk '$1=="build" && $2 ~ /^GOARCH=/ {print substr($2, 8)}')"; \
+    echo "==> built ${built_os}/${built_arch}"; \
+    if [ "${built_os}/${built_arch}" != "${TARGETOS}/${TARGETARCH}" ]; then \
+        echo "FATAL: binary is ${built_os}/${built_arch} but target is ${TARGETOS}/${TARGETARCH}" >&2; \
+        exit 1; \
+    fi
 
 FROM alpine:latest
 
@@ -51,5 +72,28 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 
 COPY --from=builder /app/rmm-tracker .
+
+# Authoritative architecture guard.
+#
+# This stage is NOT pinned to $BUILDPLATFORM, so its architecture comes from
+# buildx's --platform directly rather than from an ARG.  That makes it the only
+# place that can detect the issue #124 failure mode, where the ARG itself was
+# wrong and every ARG-based check agreed with it.
+#
+# e_machine is a little-endian 2-byte field at offset 18 of the ELF header:
+# 0x3e -> x86-64, 0xb7 -> aarch64.
+RUN set -eu; \
+    image_arch="$(apk --print-arch)"; \
+    machine="$(od -An -tx1 -j18 -N2 rmm-tracker | tr -d ' \n')"; \
+    case "${machine}" in \
+        3e00) binary_arch="x86_64" ;; \
+        b700) binary_arch="aarch64" ;; \
+        *)    binary_arch="unknown(0x${machine})" ;; \
+    esac; \
+    echo "==> image arch ${image_arch}, binary arch ${binary_arch}"; \
+    if [ "${binary_arch}" != "${image_arch}" ]; then \
+        echo "FATAL: ${image_arch} image contains a ${binary_arch} binary" >&2; \
+        exit 1; \
+    fi
 
 ENTRYPOINT ["./rmm-tracker", "run"]


### PR DESCRIPTION
Closes #124.

## Cause

`ARG TARGETOS=linux` / `ARG TARGETARCH=amd64` gave a **default value** to predefined platform ARGs. A default masks the value buildx injects, so the builder stage read the literal `amd64` for every target platform and cross-compiled amd64 even when the final stage was correctly tagged arm64.

The published index was fine and Docker reported `linux/arm64` — only the *content* of the arm64 variant was wrong, which is why nothing downstream complained.

Minimal reproduction, on an arm64 host:

```console
$ printf 'FROM --platform=$BUILDPLATFORM alpine AS b\nARG TARGETARCH=amd64\nRUN echo "seen=$TARGETARCH" > /out\nFROM alpine\nCOPY --from=b /out /out\n' > Dockerfile
$ docker buildx build --platform linux/arm64 --output type=local,dest=out . && cat out/out
seen=amd64          # <-- default wins

# same file with a bare `ARG TARGETARCH`
seen=arm64
```

The cache-mount `id=go-build-${TARGETARCH}` hypothesis from the issue is **refuted**: the field does expand correctly (build logs show `id=go-build-amd64` and `id=go-build-arm64` as distinct steps), and in any case Go's build cache is keyed on GOARCH, so a shared cache cannot emit wrong-architecture code. It looked suspicious only because `${TARGETARCH}` was wrong there too — a symptom, not the cause.

## Changes

- Drop the defaults: `ARG TARGETOS` / `ARG TARGETARCH`, plus a `${VAR:?}` assertion so a builder that does not inject them fails loudly instead of silently.
- Echo the resolved `TARGETOS/TARGETARCH` and the build host before `go build`, so a silent fallback is visible in CI logs.
- **Architecture guard in the final stage**: compares the binary's ELF `e_machine` against `apk --print-arch` and fails the build on mismatch.

The guard is deliberately in the *final* stage. That stage's platform comes from `--platform`, not from an ARG, so it is the only place that can catch a wrong ARG — an ARG-based check would have agreed with the bug and stayed green.

## Verification

Multi-platform build with the fix, binaries extracted from the final stage:

```
linux_amd64  file: x86-64      go: GOARCH=amd64
linux_arm64  file: ARMaarch64  go: GOARCH=arm64
```

Sabotage test — defaults reintroduced, built for `linux/arm64`:

```
#15 ==> built linux/amd64                                  <- builder check stays silent
#19 ==> image arch aarch64, binary arch x86_64
#19 FATAL: aarch64 image contains a x86_64 binary
#19 ERROR: process "/bin/sh -c set -eu; ..." did not complete successfully: exit code: 1
```

Also confirmed the currently published image is affected: the binary pulled from the arm64 manifest is `ELF 64-bit LSB executable, x86-64` with `build GOARCH=amd64`.

`task test` passes; `task docker:build` passes and now produces a native arm64 image locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)